### PR TITLE
add command should only be available to people with `StressedOut` rol…

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -56,7 +56,7 @@ async def stressmeout(interaction: Interaction):
     await interaction.send(embeds=[embed])
 
 
-@bot.slash_command(name="add", description="add a reminder", guild_ids=[TEST_SERVER_ID], default_member_permissions=Permissions(administrator=True, StressedOut=True))
+@bot.slash_command(name="add", description="add a reminder", guild_ids=[TEST_SERVER_ID], default_member_permissions=Permissions(administrator=True))
 async def add(
         interaction: Interaction,
         reminder_name: str,

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import os
 import datetime
 
 import nextcord
-from nextcord import Interaction
+from nextcord import Interaction, Permissions
 from nextcord.ext import commands
 
 import dbinteract
@@ -56,7 +56,7 @@ async def stressmeout(interaction: Interaction):
     await interaction.send(embeds=[embed])
 
 
-@bot.slash_command(name="add", description="add a reminder", guild_ids=[TEST_SERVER_ID])
+@bot.slash_command(name="add", description="add a reminder", guild_ids=[TEST_SERVER_ID], default_member_permissions=Permissions(administrator=True, StressedOut=True))
 async def add(
         interaction: Interaction,
         reminder_name: str,

--- a/config.py.example
+++ b/config.py.example
@@ -1,0 +1,9 @@
+
+# paste the generated token here
+# MAKESURE TOKEN IS NOVER SHARED
+TOKEN = "sample_token_here" 
+
+# copy the server id of the server where you added your bot and paste it here
+# To get the server ID right click on the server -> Copy ID
+# If the copy id option is not visible, turn on developer options in discord settings.
+TEST_SERVER_ID = 100000000000000000 

--- a/config.py.example
+++ b/config.py.example
@@ -1,9 +1,0 @@
-
-# paste the generated token here
-# MAKESURE TOKEN IS NOVER SHARED
-TOKEN = "sample_token_here" 
-
-# copy the server id of the server where you added your bot and paste it here
-# To get the server ID right click on the server -> Copy ID
-# If the copy id option is not visible, turn on developer options in discord settings.
-TEST_SERVER_ID = 100000000000000000 


### PR DESCRIPTION
…e (and admins of server) #23

<!-- You can erase any parts of this template not applicable to your Pull Request -->

# Description

In the code written in the commit made, there is an error that does not recognize StressedOut as a valid permission name. After removing it from the code it works perfectly fine i.e. only allowing administrator to use add command. Also when I created a dummy discord server for testing and added this bot then the role 'StressedOut' is not automatically being created.

## Issue Resolved

#23

## Screenshots

Provide some screenshots of the changes made (if applicable).

## Checklist

Please make sure to review the following before submitting your PR:
<!---To check the points, put a 'x' in the boxes below -->

- [x] I have read the [contribution guidelines].
- [x] I have read the code of conduct.
- [x] I have reviewed my submission in detail.